### PR TITLE
simplify expressions like 1&o. deriv 4

### DIFF
--- a/calculus.ijs
+++ b/calculus.ijs
@@ -127,7 +127,7 @@ atops =: {{
   do. x return.
   elseif.'-'-:&;:x do.
     if. 5<#toks=.;:y do.
-      if.(*/2}.}:*+/\+/1 _1*'()'=/y) * (;:'-@()') -: 0 1 2 _1 { ;: y do.
+      if.(;:'-@')-:((1;0)&{::;0&{::);y arofstringu_jcalculus_ do.
         (1+y i.'(') }. (y i:')') {. y return.
       end.
     end.

--- a/calculus.ijs
+++ b/calculus.ijs
@@ -119,18 +119,23 @@ if. 0 ~: 4!:0 <'Xvcv98df9d' do. Xvcv98df9d f. end.  NB. This sets verb result
 NB. Convert verb/noun u to string.  Must fix first in case u is a name
 strofu =: f. 1 : '5!:5 <''u'''
 
+NB. for testing partial matches between two atomic representations
+armatch=: {{
+  if. 0 e. x,&L. y do. x-:y
+  elseif. x -:&$ y do. x armatch each y
+  else. 0
+  end.
+}}
+
 NB. x and y are string forms of verb
 NB. Result is x@y in string form
 NB. simplifies some common cases
 atops =: {{
   if. isconstants x
   do. x return.
-  elseif.'-'-:&;:x do.
-    if. 5<#toks=.;:y do.
-      a=. ;y arofstringu
-      if.(;:'-@')-:((1;0)&{::;0&{::)a do.
-        (<(1;1) {:: a) vnofaru strofu return.
-      end.
+  else. a=.y arofstringu
+    if. */2{. ]S:0 a armatch {.-@%`''do.
+      (<(0;1;1) {:: a) vnofaru strofu return.
     end.
   end.
   '(',x,')@(',y,')'

--- a/calculus.ijs
+++ b/calculus.ijs
@@ -47,9 +47,18 @@ f0 =. x func y  NB. the function at the initial point
 NB. x and y are linear reps of functions
 NB. Result is linear rep of their product
 NB. Someday we may combine polynomials etc
-ftymes =: 4 : 0
-'((',x,')*(',y,'))'
-)
+NB. simplifies some common cases
+ftymes=: {{
+  if.iszeros x do. x
+  elseif.isones x do. y
+  elseif.isnones x do. '-' atops y
+  elseif.iszeros y do. y
+  elseif.isones y do. x
+  elseif.isnones y do. '-' atops x
+  else.'((',x,')*(',y,'))'
+  end.
+}}
+
 fmp =: 4 : 0  NB. same but matrix  product
 '((',x,') +/ . * (',y,'))'
 )
@@ -112,7 +121,36 @@ strofu =: f. 1 : '5!:5 <''u'''
 
 NB. x and y are string forms of verb
 NB. Result is x@y in string form
-atops =: '(',[,')@(',],')'"_
+NB. simplifies some common cases
+atops =: {{
+  if. isconstants x
+  do. x return.
+  elseif.'-'-:&;:x do.
+    if. 5<#toks=.;:y do.
+      if.(;:'-@()') -: 0 1 2 _1 { ;: y do.
+        (1+y i.'(') }. (y i:')') {. y return.
+      end.
+    end.
+  end.
+  '(',x,')@(',y,')'
+}}
+
+isconstants=: {{
+  NB. '_1"0' or '0"0' or similar
+  toks=. ;:y
+  if.3=#toks do.
+    if.(}.toks)-:;:'"0' do.
+      if. (;y arofstringu) opisnoun 0 do.
+        1 return.
+      end.
+    end.
+  end.
+  0
+}}
+
+iszeros=: -:&'0"0'
+isones=: -:&'1"0'
+isnones=: -:&'_1"0'
 
 NB. y is f;g;h, string forms
 NB. Result is fork in string form

--- a/calculus.ijs
+++ b/calculus.ijs
@@ -145,7 +145,7 @@ atops =: {{
   if. isconstants x
   do. x return.
   else. a=.y arofstringu
-    if. 1 1 0 matchsignature a armatch {.-@%`''do.
+    if. 1 1 0 matchsignature a armatch -@% arofu do.
       (<(0;1;1) {:: a) vnofaru strofu return.
     end.
   end.
@@ -156,7 +156,7 @@ NB. pessimistic:
 NB. may return 0 for some strings representing nouns
 isconstants=: {{
   NB. '_1"0' or '0"0' or similar
-  1 1 0 1 1 matchsignature y arofstringu armatch {.0"0`''
+  1 1 0 1 1 matchsignature y arofstringu armatch 0"0 arofu
 }}
 
 iszeros=: -:&'0"0'

--- a/calculus.ijs
+++ b/calculus.ijs
@@ -136,6 +136,8 @@ atops =: {{
   '(',x,')@(',y,')'
 }}
 
+NB. pessimistic: 
+NB. may return 0 for some strings representing nouns
 isconstants=: {{
   NB. '_1"0' or '0"0' or similar
   toks=. ;:y

--- a/calculus.ijs
+++ b/calculus.ijs
@@ -127,6 +127,8 @@ armatch=: {{
   end.
 }}
 
+NB. y is a result from armatch
+NB. x indicates required matching elements
 matchsignature=: {{
   t=.]S:0 y
   if.x -:&$ t do.

--- a/calculus.ijs
+++ b/calculus.ijs
@@ -127,8 +127,9 @@ atops =: {{
   do. x return.
   elseif.'-'-:&;:x do.
     if. 5<#toks=.;:y do.
-      if.(;:'-@')-:((1;0)&{::;0&{::);y arofstringu do.
-        (1+y i.'(') }. (y i:')') {. y return.
+      a=. ;y arofstringu
+      if.(;:'-@')-:((1;0)&{::;0&{::)a do.
+        (<(1;1) {:: a) vnofaru strofu return.
       end.
     end.
   end.

--- a/calculus.ijs
+++ b/calculus.ijs
@@ -127,7 +127,7 @@ atops =: {{
   do. x return.
   elseif.'-'-:&;:x do.
     if. 5<#toks=.;:y do.
-      if.(;:'-@()') -: 0 1 2 _1 { ;: y do.
+      if.(*/2}.}:*+/\+/1 _1*'()'=/y) * (;:'-@()') -: 0 1 2 _1 { ;: y do.
         (1+y i.'(') }. (y i:')') {. y return.
       end.
     end.

--- a/calculus.ijs
+++ b/calculus.ijs
@@ -138,6 +138,22 @@ matchsignature=: {{
   end.
 }}
 
+NB. u is an ar, a string or a verb
+arofmoru=: {{
+  if. 0=nc<'m' do.
+    if. L. m do. m
+    else. m arofstringu
+    end.
+  else. u f. arofu
+  end.
+}}
+
+NB. determine if two functions match to a required degree
+NB. y is an armatch signature
+matches=: {{
+  y matchsignature u arofmoru armatch v arofmoru
+}}
+  
 NB. x and y are string forms of verb
 NB. Result is x@y in string form
 NB. simplifies some common cases
@@ -145,7 +161,7 @@ atops =: {{
   if. isconstants x
   do. x return.
   else. a=.y arofstringu
-    if. 1 1 0 matchsignature a armatch -@% arofu do.
+    if. -@% matches a 1 1 0 do.
       (<(0;1;1) {:: a) vnofaru strofu return.
     end.
   end.
@@ -156,7 +172,7 @@ NB. pessimistic:
 NB. may return 0 for some strings representing nouns
 isconstants=: {{
   NB. '_1"0' or '0"0' or similar
-  1 1 0 1 1 matchsignature y arofstringu armatch 0"0 arofu
+  0"0 matches y 1 1 0 1 1
 }}
 
 iszeros=: -:&'0"0'

--- a/calculus.ijs
+++ b/calculus.ijs
@@ -127,7 +127,7 @@ atops =: {{
   do. x return.
   elseif.'-'-:&;:x do.
     if. 5<#toks=.;:y do.
-      if.(;:'-@')-:((1;0)&{::;0&{::);y arofstringu_jcalculus_ do.
+      if.(;:'-@')-:((1;0)&{::;0&{::);y arofstringu do.
         (1+y i.'(') }. (y i:')') {. y return.
       end.
     end.

--- a/calculus.ijs
+++ b/calculus.ijs
@@ -127,6 +127,15 @@ armatch=: {{
   end.
 }}
 
+matchsignature=: {{
+  t=.]S:0 y
+  if.x -:&$ t do.
+    */,x<:t
+  else.
+    0
+  end.
+}}
+
 NB. x and y are string forms of verb
 NB. Result is x@y in string form
 NB. simplifies some common cases
@@ -134,7 +143,7 @@ atops =: {{
   if. isconstants x
   do. x return.
   else. a=.y arofstringu
-    if. */2{. ]S:0 a armatch {.-@%`''do.
+    if. 1 1 0 matchsignature a armatch {.-@%`''do.
       (<(0;1;1) {:: a) vnofaru strofu return.
     end.
   end.
@@ -145,15 +154,7 @@ NB. pessimistic:
 NB. may return 0 for some strings representing nouns
 isconstants=: {{
   NB. '_1"0' or '0"0' or similar
-  toks=. ;:y
-  if.3=#toks do.
-    if.(}.toks)-:;:'"0' do.
-      if. (;y arofstringu) opisnoun 0 do.
-        1 return.
-      end.
-    end.
-  end.
-  0
+  1 1 0 1 1 matchsignature y arofstringu armatch {.0"0`''
 }}
 
 iszeros=: -:&'0"0'

--- a/manifest.ijs
+++ b/manifest.ijs
@@ -6,7 +6,7 @@ DESCRIPTION=: 0 : 0
 Conjunctions to perform differentiation and integration of J verbs, and secant-slope approximation for verbs that cannot be handled symbolically
 )
 
-VERSION=: '1.0.6'
+VERSION=: '1.0.7'
 
 FILES=: 0 : 0
 calculus.ijs
@@ -14,4 +14,4 @@ calculus.ijs
 
 FOLDER=: 'math/calculus'
 
-RELEASE=: 'j901'
+RELEASE=: 'j902'


### PR DESCRIPTION
Simplifies some common cases rather than the worst case general cases.

Also adopts the use of j902 {{ }} in some definitions