### PR TITLE
More informative error reports

### DIFF
--- a/calculus.ijs
+++ b/calculus.ijs
@@ -3,6 +3,13 @@ NB. deriv, pderiv, sslope
 NB. Interface is like d., D., D:   sample sentences at end of file
 
 cocurrent 'jcalculus'
+FANCY   =: 1 NB. setting triggering display of fancy errors, rather than a plain domain error
+NB. Commodity functions
+errname =: (9!:8'') {::~ <:
+fmterr  =: [: {{y[REPORT=:3;''}} errname@[,(LF,'|'),] NB. format error and reset it
+ferror  =: ([ 13!:8~ fmterr)&>/
+domerr  =: 13!:8@3
+error   =: domerr`ferror@. NB. Note, the naming is on purpose.
 
 NB. Derivative operator, like d.
 deriv =: 2 : 0
@@ -17,15 +24,15 @@ NB. Find the derivative of the AR.
   try.
     resstg =. 0:`derivstg`intstg@.(*order) resstg
   catch.
-    break.  NB. keep resstg/order from the last successful calculation
+    break.  NB. keep resstg/order from the last successful calculation, will rethrow error if needed later.
   end.
   order =. order - *order   NB. Decrement # orders remaining
 end.
 NB. resstg has the string form and order is the number of derivs unfinished.  Return appropriately
-if. order < 0 do. 13!:8 (3)  end.  NB. domain error if we don't know the integral
+if. order < 0 do. FANCY error REPORT end. NB. domain error if we don't know the integral
 NB. Parse the verb to create a verb
 NB. Return the verb itself if it's the right order, otherwise error.  We could do secant approx instead of error
-if. order=0 do. resstg vnofu else. 13!:8 (3) end.
+if. order=0 do. resstg vnofu else. FANCY error REPORT end.
 )
 
 NB. Routine to handle unevaluable derivatives by approximation, or D:
@@ -33,10 +40,10 @@ NB. x is amount to change eval point (0 is replaced by 1e_7)
 NB. y is eval point
 NB. Dyad only
 derivsecant =: 2 : 0
-NB. Get function to use: u. or higher-order secant 
+NB. Get function to use: u. or higher-order secant
 if. n = 1 do. func =. u.@] else. func =. u. derivsecant_jcalculus_ (n-1) end.
 NB. x must be an atom or conform to shape of y
-if. 0=#@$x do. x =. ($y)$x end.  NB. replicate atom
+if. 0=#@$x do. x =. ($y)$x end. NB. replicate atom
 assert. x -:&$ y  NB. shapes must agree
 x =. x + ((1e_7"0)`(1r10000000"0) @. (64 128 e.~ 3!:0) y) * 0 = x  NB. replace 0 by epsilon; preserve rationality.
 newy =. y +"(#@$y) (,~$x) $ (#~  1 j. #) ,x  NB. array of moved points, each an array with 1 nonzero
@@ -104,7 +111,7 @@ vnofaru =: 5!:0
 NB. Convert string u to verb/noun
 vnofu =: 1 : 0
 (0!:100) 'Xvcv98df9d =. ' , u  NB. This sets noun result
-if. 0 ~: 4!:0 <'Xvcv98df9d' do. Xvcv98df9d f. end.  NB. This sets verb result
+if. 0 ~: 4!:0 <'Xvcv98df9d' do. Xvcv98df9d f. end. NB. This sets verb result
 )
 
 NB. Convert verb/noun u to string.  Must fix first in case u is a name
@@ -141,7 +148,7 @@ if. 1 (>: L.) yar do.
   NB. Look it up in the derivative table
   if. (#primvb) > primno =. primvb i. yar do. primno {:: primderiv return. end.
   NB. If undifferentiable primitive, fail
-  13!:8 (3)
+  domerr REPORT =: 3;'undifferentiable primitive: ',y,' '
 end.
 NB. Not a primitive or named verb.  Must be a 2-box list.  The first box indicates the (possibly invisible)
 NB. modifier; process it if we know it
@@ -160,7 +167,7 @@ case. <,'3' do.  NB. fork
   case. <,'*' do. (df ftymes harg) fplus (farg ftymes dh) return.  NB. product rule
   case. <,',' do. '(',df,') , (',dh,')' return.
   case. <,'%' do. ((df ftymes harg) fminus (farg ftymes dh)) fdiv '*:' atops harg return.  NB. quotient rule
-  case. <,'^' do. ((dh ftymes ( '^.' atops farg)) fplus ((harg ftymes df) fdiv  farg)) ftymes (farg fexp harg)  return. NB. (f^g)' = (^ (g * ^. f))' 
+  case. <,'^' do. ((dh ftymes ( '^.' atops farg)) fplus ((harg ftymes df) fdiv  farg)) ftymes (farg fexp harg)  return. NB. (f^g)' = (^ (g * ^. f))'
   end.
 
 case. <,'&' do.  NB. & - first check for bonded constant
@@ -168,46 +175,46 @@ case. <,'&' do.  NB. & - first check for bonded constant
     nounarg =. (yar opar 0) vnofaru  NB. m
     verbarg =. (yar opar 1)  NB. v as an AR
     if. verbarg -: <'p.' do.   NB. Handle p. as a special case
-      if. 0 (< L.) nounarg do. nounarg =. p. nounarg end.  NB. convert multiplier or multinomial form to coeffs
+      if. 0 (< L.) nounarg do. nounarg =. p. nounarg end. NB. convert multiplier or multinomial form to coeffs
       coeffs=. ": (* #\)@}. nounarg
-      NB. special case for 0&p. 
+      NB. special case for 0&p.
       if. coeffs -: '' do. '0&p.' return.
       else.
         coeffs,'&p.' return.
       end.
     end.
-    if. *@#@$ nounarg do. 13!:8 (3) end. NB. except for p. only atomic m is recognized
+    if. *@#@$ nounarg do. domerr REPORT =: 3;'only atomic m allowed in m& (except with p.) in: ',y,' ' end. NB. except for p. only atomic m is recognized
     NB. Look it up in the derivative table, execute it on m, return string result
     if. (#primmandv) > primno =. primmandv i. verbarg do.
       (nounarg 1 : (primno {:: primmandvderiv)) strofu return.
     end.
     NB. If undifferentiable primitive, fail
-    13!:8 (3)
+    domerr REPORT =: 3;'undifferentiable combination: ',y,' '
   elseif. yar opisnoun 1 do.   NB. u&n  (u must be a verb)
     nounarg =. (yar opar 1) vnofaru  NB. n
     verbarg =. (yar opar 0)  NB. u as an AR
-    if. *@#@$ nounarg do. 13!:8 (3) end. NB. except for p. only atomic m is recognized
+    if. *@#@$ nounarg do. domerr REPORT =: 3;'only atomic n allowed in &n in: ',y,' ' end. NB. only atomic m is recognized
     NB. Look it up in the derivative table, execute it on m, return string result
     if. (#primuandn) > primno =. primuandn i. verbarg do.
       (nounarg 1 : (primno {:: primuandnderiv)) strofu return.
     end.
     NB. If undifferentiable primitive, fail
-    13!:8 (3)
+    domerr REPORT =: 3;'undifferentiable combination: ',y,' '
   end.
   NB. fallthrough cases are u&v
 
 fcase. ;:'&:@@:' do.  NB. chain rule, including fallthrough from &
-  if. yar opisnoun 1 do. 13!:8 (3) end.  NB. v must be a verb
+  if. yar opisnoun 1 do. domerr REPORT =: 3;'v must be a verb in: ',y,' ' end. NB. v must be a verb
   uop =. yar opstr 0   NB. the verb as a string
   vop =. yar opstr 1   NB. the verb as a verb
   (derivstg vop) ftymes (derivstg uop) atops vop return.
 
 case. <'^:' do.  NB. power
-  if. yar opisnoun 0 do. 13!:8 (3) end.  NB. u must be a verb
-  if. -. yar opisnoun 1 do. 13!:8 (3) end.  NB. v must be a noun
+  if. yar opisnoun 0 do. domerr REPORT =:3;'u in u^: must be a verb in: ',y,' ' end. NB. u must be a verb TODO: isn't this always the case?
+  if. -. yar opisnoun 1 do. domerr REPORT =: 3;'n in ^:n must be a noun in: ',y,' ' end. NB. v (n) must be a noun
   nop =. (yar opar 1) vnofaru  NB. extract the noun
-  if. '' -.@-: $nop do. 13!:8 (3) end.  NB. must be an atom
-  if. nop ~: <.nop do. 13!:8 (3) end. NB. must be integral
+  if. '' -.@-: $nop do. domerr REPORT =: 3;'n in ^:n must be an atom in: ',y,' ' end. NB. must be an atom
+  if. nop ~: <.nop do. domerr REPORT =: 3;'n in ^:n must be an integral number in: ',y,' ' end. NB. must be integral TODO: isn't this always the case?
   uop =. (yar opar 0) vnofaru   NB. the verb as a verb
   if. nop < 0 do.  NB. If power is negative, replace the function with its inverse
     uop =. ((< (1;0)&{:: yar) 5!:0) b. _1  NB. inverse as a string
@@ -223,11 +230,11 @@ case. <'^:' do.  NB. power
   return.
 
 case. <,'"' do.  NB. rank
-  if. -. yar opisnoun 1 do. 13!:8 (3) end.  NB. v must be a noun
+  if. -. yar opisnoun 1 do. 13!:8 (3) end. NB. v must be a noun
   nop =. (yar opar 1) vnofaru   NB. extract the noun
   uop =. (yar opar 0) vnofaru  NB. v, either verb or noun
   if. yar opisnoun 0 do.
-    if. nop = #@$ uop do. '0"0' return. end.  NB. value"0 or equivalent
+    if. nop = #@$ uop do. '0"0' return. end. NB. value"0 or equivalent
   else. (derivstg uop strofu) ranks nop return.
   end.
 
@@ -235,7 +242,7 @@ case. <,'~' do.  NB. reflexive - only a few verbs supported
   NB. Look it up in the derivative table
   if. (#primrefvb) > primno =. primrefvb i. 1 {:: yar do. primno {:: primrefderiv return. end.
 end.
-13!:8 (3)   NB. Unknown or unprocessed modifier, fail
+domerr REPORT =: 3;'unknown or unprocessed modifier in: ',y,' '    NB. Unknown or unprocessed modifier, fail
 )
 
 NB. Canned table of derivatives for the primitive verbs
@@ -324,7 +331,7 @@ case. 3 do. %@*:@(2&o.)
 case. 5 do. 6&o.
 case. 6 do. 5&o.
 case. 7 do. %@*:@(6&o.)
-case. do. 13!:8 (3) NB. if unknown type, fail
+case. do. domerr REPORT =: 3;'unimplemented derivative for ',(":m),'&o. '  NB. if unknown type, fail
 end.
 )
 
@@ -341,21 +348,21 @@ if. # ypoly =. topoly yar do.  (0j17 ": 0 , (% #\) ypoly),'&p.' return. end.
 NB. Top-down recursion through the AR
 if. 1 (>: L.) yar do.
   NB. Unboxed contents.  It's a primitive or a name
-  NB. Look it up in the derivative table
+  NB. Look it up in the integral table
   if. (#intprimvb) > primno =. intprimvb i. yar do. primno {:: primint return. end.
-  NB. If undifferentiable primitive, fail
-  13!:8 (3)
+  NB. If unintegrable primitive, fail, with informative message
+  domerr REPORT =: 3;'unintegrable primitive: ',y,' '
 end.
 NB. Not a primitive or named verb.  Must be a 2-box list.  The first box indicates the (possibly invisible)
 NB. modifier; process it if we know it
 yar =. > yar  NB. discard outer boxing
 select. {.yar
 case. <,'0' do.  NB. noun - should not occur
-case. <,'2' do.  NB. hhok - not supported
+case. <,'2' do.  NB. hook - not supported
 case. <,'3' do.  NB. fork
   'farg garg harg' =. yar&opstr&.> 0 1 2
-  if. (<'[:') -: yar opar 0 do. 13!:8 (3) end.   NB. [: g h
-  if. yar opisnoun 0 do. 13!:8 (3) return. end. NB. n v v
+  if. (<'[:') -: yar opar 0 do. domerr REPORT =: 3;'capped fork not implemented: ',y,' ' end.   NB. [: g h TODO: why so?
+  if. yar opisnoun 0 do. domerr REPORT =: 3;'noun-verb-verb fork not implemented: ',y,' ' end. NB. n v v   TODO: Why so?
   pf =. topoly farg [ ph =. topoly harg
   select. garg
   case. <,'+' do. if. pf *.&(*&#) ph do. intstg pf pplus ph else. forks (intstg pf);garg;(intstg ph) end. return.
@@ -367,23 +374,23 @@ case. <,'&' do.  NB. & - first check for bonded constant
   if. yar opisnoun 0 do.   NB. m&v  (v must be a verb)
     nounarg =. (yar opar 0) vnofaru  NB. m
     verbarg =. (yar opar 1)  NB. v as an AR
-    if. *@#@$ nounarg do. 13!:8 (3) end. NB. except for p. handled above, only atomic m is recognized
+    if. *@#@$ nounarg do. domerr REPORT =: 3;'only atomic m supported in m&v (except for p.) in: ',y, ' ' end. NB. except for p. handled above, only atomic m is recognized
     NB. Look it up in the integral table, execute it on m, return string result
     if. (#primintmandvvb) > primno =. primintmandvvb i. verbarg do.
       (nounarg 1 : (primno {:: primintmandv)) strofu return.
     end.
-    NB. If undifferentiable primitive, fail
-    13!:8 (3)
+    NB. If unintegrable primitive, fail
+    domerr REPORT =: 3;'unintegrable combination: ',y,' '
   elseif. yar opisnoun 1 do.   NB. u&n  (u must be a verb)
     nounarg =. (yar opar 1) vnofaru  NB. n
     verbarg =. (yar opar 0)  NB. u as an AR
-    if. *@#@$ nounarg do. 13!:8 (3) end. NB. except for p. only atomic m is recognized
+    if. *@#@$ nounarg do. domerr REPORT =: 3;'only atomic n supported in u&n in: ',y,' ' end. NB. only atomic m is recognized
     NB. Look it up in the derivative table, execute it on m, return string result
     if. (#primintuandnvb) > primno =. primintuandnvb i. verbarg do.
       (nounarg 1 : (primno {:: primintuandn)) strofu return.
     end.
     NB. If undifferentiable primitive, fail
-    13!:8 (3)
+    domerr REPORT =: 3;'only atomic n supported in u&n: ',y, ' '
   end.
 
   NB. fallthrough cases are u&v
@@ -391,23 +398,23 @@ fcase. ;:'&:@@:' do.  NB. f@g (verb only)
   if. # upoly =. topoly yar opar 0 do.  NB. if u is a polynomial
     if. (-: 1 {.~ -@#) upoly do.
       NB. Handle ^&m for the cases we know
-      if. 1 = #upoly do. ']' return. end.  NB. 1@g, just like 1
+      if. 1 = #upoly do. ']' return. end. NB. 1@g, just like 1
       vop =. yar opstr 1   NB. v as a string
       if. 2 = #upoly do. intstg vop return. end.
       if. (#primintpatopvb) > primno =. primintpatopvb i. <vop do.
         ((<: #upoly) 1 : (primno {:: primintpatopint)) strofu return.
       end.
     end.
-    NB. If undifferentiable primitive, fail
-    13!:8 (3)
+    NB. If unintegrable rimitive, fail
+    domerr REPORT=: 3;'unintegrable combination: ',y,' '
   end.
 
 case. <'^:' do.  NB. power
-  if. yar opisnoun 0 do. 13!:8 (3) end.  NB. u must be a verb
-  if. -. yar opisnoun 1 do. 13!:8 (3) end.  NB. v must be a noun
+  if. yar opisnoun 0 do. domerr REPORT=:3;'u in u^: must be a verb in: ',y,' ' end. NB. u must be a verb
+  if. -. yar opisnoun 1 do. domerr REPORT=:3;'n in u^:n must be a noun in: ',y,' ' end. NB. v must be a noun
   nop =. (yar opar 1) vnofaru  NB. extract the noun
-  if. '' -.@-: $nop do. 13!:8 (3) end.  NB. must be an atom
-  if. nop ~: <.nop do. 13!:8 (3) end. NB. must be integral
+  if. '' -.@-: $nop do. domerr REPORT=:3;'n in u^:n must be an atom in: ', y,' ' end. NB. must be an atom
+  if. nop ~: <.nop do. domerr REPORT =:3;'n in u^:n must be integral in: ',y,' ' end. NB. must be integral
   uop =. (yar opar 0) vnofaru   NB. the verb as a verb
   if. nop < 0 do.  NB. If power is negative, replace the function with its inverse
     uop =. ((< (1;0)&{:: yar) 5!:0) b. _1  NB. inverse as a string
@@ -423,11 +430,11 @@ case. <'^:' do.  NB. power
   return.
 
 case. <,'"' do.  NB. rank
-  if. -. yar opisnoun 1 do. 13!:8 (3) end.  NB. v must be a noun
+  if. -. yar opisnoun 1 do. domerr REPORT=:'m in "m must be a noun in: ',y,' ' end. NB. v must be a noun
   nop =. (yar opar 1) vnofaru   NB. extract the noun
   uop =. (yar opar 0) vnofaru  NB. v, either verb or noun
   if. yar opisnoun 0 do.
-    if. nop = #@$ uop do. (":uop),'&*' return. end.  NB. value"0 or equivalent
+    if. nop = #@$ uop do. (":uop),'&*' return. end. NB. value"0 or equivalent
   else. (intstg uop strofu) ranks nop return.
   end.
 
@@ -435,7 +442,7 @@ case. <,'~' do.  NB. reflexive - only a few verbs supported
   NB. Look it up in the integral table
   if. (#intrefvb) > primno =. intrefvb i. 1 {:: yar do. primno {:: refint return. end.
 end.
-13!:8 (3)   NB. Unknown or unprocessed modifier, fail
+domerr REPORT =: 3;'unknown or unprocessed modifier in: ', y,' '  NB. Unknown or unprocessed modifier, fail
 )
 
 
@@ -524,7 +531,7 @@ case. 3 do. -@^.@(2&o.)
 case. 5 do. 6&o.
 case. 6 do. 5&o.
 case. 7 do. ^.@(6&o.)
-case. do. 13!:8 (3) NB. if unknown type, fail
+case. do. domerr REPORT =: 3;'unknown integral for ',(":m),'&o. '  NB. if unknown type, fail
 end.
 )
 
@@ -544,7 +551,7 @@ for_lsb. }. #: {. y do. x =. x0 ptymes^:lsb x ptymes x end.
 
 NB. y is a string or an AR, result is the polynomial
 topoly =: 3 : 0
-if. 0 (>: L.) yar =. y do. yar =. y arofstringu end.  NB. AR of y
+if. 0 (>: L.) yar =. y do. yar =. y arofstringu end. NB. AR of y
 NB. Top-down recursion through the AR
 if. 1 (>: L.) yar do.
   NB. Unboxed contents.  It's a primitive or a name
@@ -558,14 +565,14 @@ NB. modifier; process it if we know it
 yar =. > yar  NB. discard outer boxing
 select. {.yar
 case. <,'0' do.  NB. noun
-  if. '' -: $nounarg =. 1{::yar do. ,nounarg return. end.  NB. If an atom, treat as polynomial constant
+  if. '' -: $nounarg =. 1{::yar do. ,nounarg return. end. NB. If an atom, treat as polynomial constant
   '' return.  NB. error otherwise
 case. <,'2' do.  NB. hook - not supported
 case. <,'3' do.  NB. fork
   'farg garg harg' =. yar&opstr&.> 0 1 2
   if. (<'[:') -: yar opar 0 do. topoly garg atops harg return. end.   NB. [: g h
   f =. topoly farg [ h =. topoly harg
-  if. 0 = f *.&# h do. '' return. end.  NB. f and h must be polynomials
+  if. 0 = f *.&# h do. '' return. end. NB. f and h must be polynomials
   select. garg
   case. <,'+' do. f pplus h return.
   case. <,'-' do. f pminus h return.
@@ -579,23 +586,23 @@ case. <,'&' do.
     verbarg =. (yar opar 1)  NB. v as an AR
     if. verbarg -: <'p.' do.   NB. Handle p. as a special case
       if. 0 (< L.) nounarg do.   NB.  roots or multinomial
-        if. 1 < #nounarg do. p. nounarg return. end.  NB. roots: convert to coeffs and return
-        if. (2 = #@$ > nounarg) *. (2 = {>@$ > nounarg) do. p. nounarg return. end.  NB. multinomial convert to coeffs and return
+        if. 1 < #nounarg do. p. nounarg return. end. NB. roots: convert to coeffs and return
+        if. (2 = #@$ > nounarg) *. (2 = {>@$ > nounarg) do. p. nounarg return. end. NB. multinomial convert to coeffs and return
         $0 return.  NB. Bad shape, not polynomial
       end.
       (,nounarg) return.   NB. coeffs, return them
     end.
-    if. *@#@$ nounarg do. 13!:8 (3) end. NB. except for p. only atomic m is recognized
+    if. *@#@$ nounarg do. domerr REPORT =: 3;'only atomic m supported in m&v (except for m&p.) in: ',y,' ' end. NB. except for p. only atomic m is recognized
     NB. Look it up in the polynomial table, execute it on m, return string result
     if. (#primpmandvvb) > primno =. primpmandvvb i. verbarg do.
       (nounarg 1 : (primno {:: primpmandv))  return.
     end.
     $0 return.
-    
+
   elseif. yar opisnoun 1 do.   NB. u&n  (u must be a verb)
     nounarg =. (yar opar 1) vnofaru  NB. n
     verbarg =. (yar opar 0)  NB. u as an AR
-    if. *@#@$ nounarg do. 13!:8 (3) end. NB. except for p. only atomic m is recognized
+    if. *@#@$ nounarg do. domerr REPORT =: 3;'only atomic n supported in u&n in: ',y,' ' end. NB. only atomic m is recognized
     NB. Look it up in the polynomial table, execute it on m, return string result
     if. (#primpuandnvb) > primno =. primpuandnvb i. verbarg do.
       (nounarg 1 : (primno {:: primpuandn))  return.
@@ -610,15 +617,15 @@ case. <,'&' do.
 case. ;:'&:@@:' do.
   'uarg varg' =. yar&opstr&.> 0 1
   f =. topoly uarg [ h =. topoly varg
-  if. 0 = f *.&# h do. '' return. end.  NB. f and h must be polynomials
+  if. 0 = f *.&# h do. '' return. end. NB. f and h must be polynomials
   +/ f * h pexp"_ 0 i. #f return.
 
 case. <'^:' do.  NB. power
   'uarg varg' =. yar&opstr&.> 0 1
   f =. topoly uarg [ h =. topoly varg
-  if. 0 = f *.&# h do. '' return. end.  NB. f and h must be polynomials
+  if. 0 = f *.&# h do. '' return. end. NB. f and h must be polynomials
   if. h ~: <. h do. $0 return. end.
-  if. h < 0 do. $0 return. end.  NB. h must be positive
+  if. h < 0 do. $0 return. end. NB. h must be positive
   select. h
   case. 1 do. f
   case. 0 do. 0 1
@@ -629,7 +636,7 @@ case. <'^:' do.  NB. power
 case. <,'"' do.  NB. rank
   'uarg varg' =. yar&opstr&.> 0 1
   f =. topoly uarg [ h =. topoly varg
-  if. 0 = f *.&# h do. '' return. end.  NB. f and h must be polynomials
+  if. 0 = f *.&# h do. '' return. end. NB. f and h must be polynomials
   f return.  NB. If an atom, treat as polynomial constant
 
 case. <,'~' do.  NB. reflexive - these cases are rare & we ignore them
@@ -699,7 +706,7 @@ assert. '' -: $n   NB. n must be an atom
 order =. <. n
 assert. n = order
 assert. 3 = 4!:0 <'u'   NB. Must be in user's namespace
-if. order < 0 do. 13!:8 (3)  end.  NB. integrals not allowed
+if. order < 0 do. error 3;'Integrals not allowed' end. NB. integrals not allowed
 ufix =. u. f.  NB. u in user's namespace
 resstg =. 5!:5 <'ufix'   NB. User's verb in character form
 while. order do.   NB. If the order is not 1 or _1, keep increasing the order.
@@ -707,6 +714,7 @@ NB. Find the derivative of the AR.  If it fails at any point, revert to secant a
   try.
     resstg =. pderivstg resstg
   catch.
+    echo^:FANCY 'Falling back to approximation due to: ',1{:: REPORT
     break.  NB. keep resstg/order from the last successful calculation
   end.
   order =. <: order   NB. Decrement # orders remaining
@@ -717,7 +725,7 @@ NB. Return the verb itself if it's the right order, otherwise a call to the appr
 if. order=0 do. resstg vnofu else. 0&(resstg vnofu derivsecant_jcalculus_ order) end.
 )
 
-NB. symbolic partial  derivative, in string form
+NB. symbolic partial derivative, in string form
 NB. y is string form of a verb
 NB. Result is string form of the derivative verb
 NB. If we don't know the derivative, we raise an error
@@ -730,11 +738,11 @@ try.
   NB.  if not rnk  0, append the multivariate appendix
   if. 0 ~: {. (d vnofu) b. 0 do. d =. '(* =/~@(i.@$))@(',d,')' end.
   d  return.
-catch.
+catch. NB. Do NOT rethrow the error here... this is for tentative execution.
 end.
 NB. Try the forms that have no variables, on the original string verb
 if. (#primpvb) > primno =. primpvb i. yar do. primno {:: primpderiv return. end.
-if. 1 (>: L.) yar do. 13!:8 (3) end.   NB. If undifferentiable primitive, fail
+if. 1 (>: L.) yar do. domerr REPORT=: 3;'undifferentiable primitive ',y  end.   NB. If undifferentiable primitive, fail
 
 NB. Not a primitive or named verb.  Must be a 2-box list.  The first box indicates the (possibly invisible)
 NB. modifier; process it if we know it
@@ -761,27 +769,27 @@ case. <,'&' do.  NB. &
     if. verbarg e. ;:'|. |: { A. C.' do.   NB. perm type
       '(=/ ',y,')@(i.@$)' return.
     end.
-    13!:8 (3)
+    domerr REPORT=: 3; 'm&',y,'not allowed'
   end.
   NB. fallthrough cases are u&v
 
 fcase. ;:'&:@@:' do.  NB. chain rule, including fallthrough from &
-  if. yar opisnoun 1 do. 13!:8 (3) end.  NB. v must be a verb
+  if. yar opisnoun 1 do. domerr REPORT=:3;'v in &:v, @v or @:v must be verb in ',y end. NB. v must be a verb
   uop =. yar opstr 0   NB. the verb as a string
   vop =. yar opstr 1   NB. the verb as a verb
   (pderivstg vop) fmp (pderivstg uop) atops vop return.
 
 case. <,'"' do.  NB. rank
-  if. -. yar opisnoun 1 do. 13!:8 (3) end.  NB. v must be a noun
+  if. -. yar opisnoun 1 do. domerr REPORT=:3;' n must be noun in u"n' end. NB. v must be a noun
   nop =. (yar opar 1) vnofaru   NB. extract the noun
   uop =. (yar opstr 0) vnofaru  NB. extract the verb u as a string
-  if. -. yar opisnoun 0 do. (pderivstg uop),'"',":nop  end.  NB. u is a verb
+  if. -. yar opisnoun 0 do. (pderivstg uop),'"',":nop end. NB. u is a verb
   '$&0@0"',":nop return.
 
 case. <,'~' do.  NB. reflexive - these cases are rare & we ignore them
 NB. +/ omitted
 end.
-13!:8 (3)   NB. Unknown or unprocessed modifier, fail
+domerr REPORT =: 3;'unknown or unprocessed modifier ',>{.yar   NB. Unknown or unprocessed modifier, fail
 )
 
 NB. Canned table of derivatives for the primitive verbs
@@ -794,12 +802,17 @@ NB. Canned table of derivatives for the primitive verbs
 
 NB. Secant slope, like D:
 sslope =: 2 : 0
-assert. _1 = 4!:0 <'m'  NB. u is verb
-assert. 0 = 4!:0 <'n'  NB. v is a noun
-assert. 0 = #$n  NB. n is an atom
-assert. n > 0   NB. n > 0
+if. _1 ~: 4!:0 <'m' do. domerr REPORT=: 3;'u most be a verb' end.  NB. u is verb
+if.  0 ~: 4!:0 <'n' do. domerr REPORT=: 3;'n must be a noun' end.  NB. v is a noun
+if. 0 ~: #$n        do. domerr REPORT=: 3;'n must be an atom' end. NB. n is an atom
+if. n <: 0          do. domerr REPORT=: 3;'n must be larger than 0' end. NB. n > 0
 (u. derivsecant_jcalculus_ n)"(u. f. b. 0)
 )
+
+NB. export relevant verbs to z
+deriv_z_ =: deriv_jcalculus_
+pderiv_z_ =: pderiv_jcalculus_
+sslope_z_ =: sslope_jcalculus_
 
 0 : 0  NB. Sample sentences
 *: deriv 1

--- a/calculus.ijs
+++ b/calculus.ijs
@@ -405,7 +405,7 @@ fcase. ;:'&:@@:' do.  NB. f@g (verb only)
         ((<: #upoly) 1 : (primno {:: primintpatopint)) strofu return.
       end.
     end.
-    NB. If unintegrable rimitive, fail
+    NB. If unintegrable primitive, fail
     domerr REPORT=: 3;'unintegrable combination: ',y,' '
   end.
 

--- a/calculus.ijs
+++ b/calculus.ijs
@@ -802,10 +802,10 @@ NB. Canned table of derivatives for the primitive verbs
 
 NB. Secant slope, like D:
 sslope =: 2 : 0
-if. _1 ~: 4!:0 <'m' do. domerr REPORT=: 3;'u most be a verb' end.  NB. u is verb
-if.  0 ~: 4!:0 <'n' do. domerr REPORT=: 3;'n must be a noun' end.  NB. v is a noun
-if. 0 ~: #$n        do. domerr REPORT=: 3;'n must be an atom' end. NB. n is an atom
-if. n <: 0          do. domerr REPORT=: 3;'n must be larger than 0' end. NB. n > 0
+if. _1 ~: 4!:0 <'m' do. FANCY error REPORT=: 3;'u most be a verb' end.  NB. u is verb
+if.  0 ~: 4!:0 <'n' do. FANCY error REPORT=: 3;'n must be a noun' end.  NB. v is a noun
+if. 0 ~: #$n        do. FANCY error REPORT=: 3;'n must be an atom' end. NB. n is an atom
+if. n <: 0          do. FANCY error REPORT=: 3;'n must be larger than 0' end. NB. n > 0
 (u. derivsecant_jcalculus_ n)"(u. f. b. 0)
 )
 


### PR DESCRIPTION
This pull request refers to [issue 7](https://github.com/jsoftware/math_calculus/issues/7)

It provides math/calculus with more informative error reports by storing the error in `REPORT_jcalculus`. Fancy error reporting can be turned of by setting `FANCY_jcalculus_` to 0.
I also exposed deriv, pderiv and sslope to the z locale for easier use.

For instance:
```j
   load 'math/calculus' NB. current version
   # deriv 1
|domain error: deriv
|       13!:8(3)

   load 'calculus.ijs' NB. version of this pull request
   # deriv 1
|domain error
|undifferentiable primitive: # : ferror
|       FANCY error REPORT
```